### PR TITLE
Removido parte da bundle 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,6 +248,3 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
-
-BUNDLED WITH
-   2.0.2


### PR DESCRIPTION
Netlify dá erro 42 com saída: failed during stage 'building site': Build script returned non-zero exit code: 42

De acordo com https://stackoverflow.com/questions/56793964/netlify-deployment-failed-during-stage-building-site-build-script-returned-n
eu removi a ultima parte do gemfile